### PR TITLE
[12.x] Add test for complex context manipulation in Logger

### DIFF
--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -103,4 +103,21 @@ class LogLoggerTest extends TestCase
 
         $writer->listen($callback);
     }
+
+    public function testComplexContextManipulation()
+    {
+        $writer = new Logger($monolog = m::mock(Monolog::class));
+
+        $writer->withContext(['user_id' => 123, 'action' => 'login']);
+        $writer->withContext(['ip' => '127.0.0.1', 'timestamp' => '1986-10-29']);
+        $writer->withoutContext(['timestamp']);
+
+        $monolog->shouldReceive('info')->once()->with('User action', [
+            'user_id' => 123,
+            'action' => 'login',
+            'ip' => '127.0.0.1',
+        ]);
+
+        $writer->info('User action');
+    }
 }


### PR DESCRIPTION
This PR adds a new test case to `LogLoggerTest.php` that demonstrates complex context manipulation scenarios in the Logger class.

The new test `testComplexContextManipulation()` covers:
- Multiple sequential context operations
- Context accumulation across multiple `withContext` calls
- Selective removal of context keys
- Preservation of context from previous operations